### PR TITLE
Add versioning on the models serializer

### DIFF
--- a/lib/biceps.rb
+++ b/lib/biceps.rb
@@ -1,7 +1,8 @@
 require 'biceps/core_ext/action_dispatch/routing/mapper'
 
 module Biceps
-  autoload :ApiVersion, 'biceps/api_version'
-  autoload :Jsonp,      'biceps/jsonp'
+  autoload :ApiVersion,      'biceps/api_version'
+  autoload :ModelVersioning, 'biceps/model_versioning'
+  autoload :Jsonp,           'biceps/jsonp'
   autoload :Serializer,      'biceps/serializer'
 end

--- a/lib/biceps.rb
+++ b/lib/biceps.rb
@@ -1,4 +1,5 @@
 require 'biceps/core_ext/action_dispatch/routing/mapper'
+require 'biceps/core_ext/action_controller/base'
 
 module Biceps
   autoload :ApiVersion,      'biceps/api_version'

--- a/lib/biceps.rb
+++ b/lib/biceps.rb
@@ -6,4 +6,5 @@ module Biceps
   autoload :Jsonp,           'biceps/jsonp'
   autoload :Serializer,      'biceps/serializer'
   autoload :Parser,          'biceps/parser'
+  autoload :Builder,         'biceps/builder'
 end

--- a/lib/biceps.rb
+++ b/lib/biceps.rb
@@ -3,4 +3,5 @@ require 'biceps/core_ext/action_dispatch/routing/mapper'
 module Biceps
   autoload :ApiVersion, 'biceps/api_version'
   autoload :Jsonp,      'biceps/jsonp'
+  autoload :Serializer,      'biceps/serializer'
 end

--- a/lib/biceps.rb
+++ b/lib/biceps.rb
@@ -5,4 +5,5 @@ module Biceps
   autoload :ModelVersioning, 'biceps/model_versioning'
   autoload :Jsonp,           'biceps/jsonp'
   autoload :Serializer,      'biceps/serializer'
+  autoload :Parser,          'biceps/parser'
 end

--- a/lib/biceps/api_version.rb
+++ b/lib/biceps/api_version.rb
@@ -1,36 +1,13 @@
 module Biceps
   class ApiVersion
-    attr_accessor :version, :accept
+    attr_accessor :version
 
     def initialize(version)
-      @version = [version].flatten
+      @version = version
     end
 
     def matches?(request)
-      @accept = request.accept
-      valid_api_version?
-    end
-
-
-    private
-    def valid_api_version?
-      version.include?(request_version)
-    end
-
-    def request_version
-      is_api_call?[1].to_i if is_api_call?
-    end
-
-    def is_api_call?
-      @is_api_call = accept.match(regex)
-    end
-
-    def regex
-      Regexp.new("application/vnd.#{app_name};ver=([0-9]+)")
-    end
-
-    def app_name
-      Rails.application.class.to_s.split('::').first.underscore
+      Biceps::Parser.new(request, version).valid?
     end
   end
 end

--- a/lib/biceps/builder.rb
+++ b/lib/biceps/builder.rb
@@ -1,0 +1,41 @@
+module Biceps
+  module Builder
+
+    # instiantiate_for_api(User, params[:user]) == Constructor.new(User,params[:user], 1)
+    def self.new(resource, params, version)
+      begin
+        constant = "Builders::#{resource}::V#{version}".constantize
+        instance = constant.new resource.new, params
+      rescue NameError
+        #
+        # The builder for that version is not defined
+        # Use the model's internal initialize
+        instance = resource.new params
+      end
+
+      instance
+    end
+
+    class Base
+      attr_reader :resource, :params
+      delegate    :respond_to?, :to => :resource
+
+      extend ActiveModel::Callbacks
+      define_model_callbacks :initialize, :only => :after
+
+      def initialize(resource, params)
+        run_callbacks :initialize do
+          @resource, @params = resource, params
+        end
+      end
+
+      def method_missing(method, *args, &block)
+        if resource.respond_to?(method)
+          resource.send(method, *args, &block)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/biceps/core_ext/action_controller/base.rb
+++ b/lib/biceps/core_ext/action_controller/base.rb
@@ -1,0 +1,7 @@
+ActionController::Base.class_eval do
+
+  def initialize_for_api(resource, params)
+    api_version = Biceps::Parser.new(request).version
+    Biceps::Builder.new(resource, params, api_version)
+  end
+end

--- a/lib/biceps/model_versioning.rb
+++ b/lib/biceps/model_versioning.rb
@@ -9,7 +9,12 @@ module Biceps
         def api_behavior(error)
           if api_version
             begin
-              constant = "Serializers::#{resource.class}::V#{api_version}".constantize
+              if resource.is_a?(Biceps::Builder::Base)
+                constant = "Serializers::#{resource.resource.class}::V#{api_version}".constantize
+              else
+                constant = "Serializers::#{resource.class}::V#{api_version}".constantize
+              end
+
               @resource = constant.new(resource)
             rescue NameError
               #

--- a/lib/biceps/model_versioning.rb
+++ b/lib/biceps/model_versioning.rb
@@ -1,0 +1,38 @@
+module Biceps
+  module ModelVersioning
+
+    def self.included(klass)
+      klass.class_eval do
+
+        protected
+        alias :old_api_behavior :api_behavior
+        def api_behavior(error)
+          if api_version
+            begin
+              constant = "Serializers::#{resource.class}::V#{api_version}".constantize
+              @resource = constant.new(resource)
+            rescue NameError
+              #
+              # The serializer for that version is not defined
+              # Use the model's internal serialize
+              #
+            end
+          end
+
+          old_api_behavior(error)
+        end
+
+        private
+        # TODO : refactor the routing constraint so we don't repeat the
+        #regex in two different places
+        def api_version
+          app_name = Rails.application.class.to_s.split('::').first.underscore
+          regex = Regexp.new("application/vnd.#{app_name};ver=([0-9]+)")
+
+          match = request.accept.match(regex) if request.accept
+          match[1].to_i if match
+        end
+      end
+    end
+  end
+end

--- a/lib/biceps/model_versioning.rb
+++ b/lib/biceps/model_versioning.rb
@@ -23,14 +23,8 @@ module Biceps
         end
 
         private
-        # TODO : refactor the routing constraint so we don't repeat the
-        #regex in two different places
         def api_version
-          app_name = Rails.application.class.to_s.split('::').first.underscore
-          regex = Regexp.new("application/vnd.#{app_name};ver=([0-9]+)")
-
-          match = request.accept.match(regex) if request.accept
-          match[1].to_i if match
+          Biceps::Parser.new(request).version
         end
       end
     end

--- a/lib/biceps/parser.rb
+++ b/lib/biceps/parser.rb
@@ -1,0 +1,31 @@
+module Biceps
+  class Parser
+    attr_accessor :request, :valid_versions
+
+    def initialize(request, valid_versions=nil)
+      @request = request
+      @valid_versions = [valid_versions].flatten
+    end
+
+    def valid?
+      valid_versions.include?(version)
+    end
+
+    def version
+      is_api_call?[1].to_i if is_api_call?
+    end
+
+    private
+    def is_api_call?
+      request.accept.match(regex) if request.accept
+    end
+
+    def regex
+      Regexp.new("application/vnd.#{app_name};ver=([0-9]+)")
+    end
+
+    def app_name
+      Rails.application.class.to_s.split('::').first.underscore
+    end
+  end
+end

--- a/lib/biceps/serializer.rb
+++ b/lib/biceps/serializer.rb
@@ -1,0 +1,22 @@
+module Biceps
+  class Serializer
+    include ActiveModel::Serialization
+    include ActiveModel::Serializers::JSON
+    include ActiveModel::Serializers::Xml
+
+    attr_accessor :parent
+    delegate :respond_to?, :to => :parent
+
+    def initialize(parent)
+      @parent = parent
+    end
+
+    def method_missing(method, *args, &block)
+      if parent.respond_to?(method)
+        parent.send(method, *args, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+module Builders
+  module Hash
+
+    class V1 < Biceps::Builder::Base
+
+      after_initialize :parse_params
+
+
+      private
+      def parse_params
+        resource[:test] = true
+      end
+    end
+  end
+end
+
+describe Biceps::Builder do
+
+  describe "new" do
+    it "should return the model if there is no api version" do
+      assert_kind_of Hash, Biceps::Builder.new(Hash, {}, nil)
+    end
+
+    it "should return the model if the version does not exists" do
+      assert_kind_of Hash, Biceps::Builder.new(Hash, {}, 42)
+    end
+
+    it "should return the builder" do
+      assert_kind_of Builders::Hash::V1, Biceps::Builder.new(Hash, {}, 1)
+    end
+  end
+
+  describe "callbacks" do
+    it "should execute the after initialize callback" do
+      instance = Biceps::Builder.new(Hash, {}, 1)
+      assert_equal({:test => true}, instance.resource)
+    end
+  end
+end

--- a/spec/model_versioning_spec.rb
+++ b/spec/model_versioning_spec.rb
@@ -17,7 +17,7 @@ describe Biceps::ModelVersioning do
 
   describe "without any api version" do
     it "should render using the normal behavior" do
-      assert_equal responder(resource).send(:api_behavior, nil),
+      assert_equal Array(responder(resource).send(:api_behavior, nil)),
         [{:test => true}.to_json]
     end
   end
@@ -27,7 +27,7 @@ describe Biceps::ModelVersioning do
       responder = responder(resource)
       responder.request.env['HTTP_ACCEPT'] = 'application/vnd.biceps;ver=1'
 
-      assert_equal responder.send(:api_behavior, nil),
+      assert_equal Array(responder.send(:api_behavior, nil)),
         [{:new_test => true}.to_json]
     end
 
@@ -35,7 +35,7 @@ describe Biceps::ModelVersioning do
       responder = responder(resource)
       responder.request.env['HTTP_ACCEPT'] = 'application/vnd.biceps;ver=2'
 
-      assert_equal responder.send(:api_behavior, nil),
+      assert_equal Array(responder.send(:api_behavior, nil)),
         [{:test => true}.to_json]
     end
   end

--- a/spec/model_versioning_spec.rb
+++ b/spec/model_versioning_spec.rb
@@ -40,6 +40,16 @@ describe Biceps::ModelVersioning do
     end
   end
 
+  describe "with a builder object" do
+    it "should return the resource's hash" do
+      responder = responder(Biceps::Builder::Base.new(resource, {}))
+      responder.request.env['HTTP_ACCEPT'] = 'application/vnd.biceps;ver=1'
+
+      assert_equal Array(responder.send(:api_behavior, nil)),
+        [{:new_test => true}.to_json]
+    end
+  end
+
   def responder(resources, accept=nil)
     Biceps::TestResponder.new(
       Biceps::TestResponderController.new,

--- a/spec/model_versioning_spec.rb
+++ b/spec/model_versioning_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Serializers
+  module Hash
+
+    class V1 < Biceps::Serializer
+
+      def as_json(opts={})
+        {:new_test => parent[:test]}
+      end
+    end
+  end
+end
+
+describe Biceps::ModelVersioning do
+  let(:resource) { {:test => true} }
+
+  describe "without any api version" do
+    it "should render using the normal behavior" do
+      assert_equal responder(resource).send(:api_behavior, nil),
+        [{:test => true}.to_json]
+    end
+  end
+
+  describe "with an api version" do
+    it "should render using the model's version behavior" do
+      responder = responder(resource)
+      responder.request.env['HTTP_ACCEPT'] = 'application/vnd.biceps;ver=1'
+
+      assert_equal responder.send(:api_behavior, nil),
+        [{:new_test => true}.to_json]
+    end
+
+    it "should not fail if there is no serializer for that version" do
+      responder = responder(resource)
+      responder.request.env['HTTP_ACCEPT'] = 'application/vnd.biceps;ver=2'
+
+      assert_equal responder.send(:api_behavior, nil),
+        [{:test => true}.to_json]
+    end
+  end
+
+  def responder(resources, accept=nil)
+    Biceps::TestResponder.new(
+      Biceps::TestResponderController.new,
+      [resources],
+      {
+        :default_response => lambda {
+          raise ActionView::MissingTemplate.new([], "", [], "")
+        }
+      }
+    )
+  end
+end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Biceps::Parser do
+  let(:request) { ACTR.new({'HTTP_ACCEPT' => 'application/json, application/vnd.biceps;ver=1'}) }
+
+  describe "initialize" do
+    it "should set the request" do
+      assert_equal Biceps::Parser.new({:test => true}).request,
+        {:test => true}
+    end
+
+    it "should set the valid versions list" do
+      assert_equal Biceps::Parser.new({}, [1, 2]).valid_versions,
+        [1, 2]
+    end
+  end
+
+  describe "valid?" do
+    it "should consider the version as valid" do
+      assert Biceps::Parser.new(request, 1).valid?
+    end
+
+    it "should not consider the version as valid" do
+      refute Biceps::Parser.new(request, 2).valid?
+    end
+  end
+
+  describe "version" do
+    it "should return the appropriate version" do
+      assert_equal Biceps::Parser.new(request).version, 1
+    end
+  end
+end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Biceps::Serializer do
+
+  describe "initialize" do
+    it "should set the parent" do
+      assert_equal Biceps::Serializer.new({:test => true}).parent,
+        {:test => true}
+    end
+  end
+
+  describe "respond_to" do
+    it "should respond true if the parent method exists" do
+      assert Biceps::Serializer.new({}).respond_to?(:each)
+    end
+
+    it "should respond false if the parent method does not exists" do
+      refute Biceps::Serializer.new({}).respond_to?(:foo)
+    end
+  end
+
+  describe "method_missing" do
+    it "should raise NoMethodError if the parent method does not exists" do
+      assert_raises NoMethodError do
+        Biceps::Serializer.new({}).foo
+      end
+    end
+
+    it "should succeed if the parent method exists" do
+      Biceps::Serializer.new({:test => true}).each do |e|
+        assert e
+      end
+    end
+  end
+end

--- a/spec/support/responder_mocks.rb
+++ b/spec/support/responder_mocks.rb
@@ -1,0 +1,28 @@
+class Biceps::TestResponder < ActionController::Responder
+  include Biceps::ModelVersioning
+end
+
+class Biceps::TestResponderController < ActionController::Base
+  attr_accessor :limit, :params
+
+  def initialize
+    @params = {}
+    @_response = ActionDispatch::Response.new
+    @_action_has_layout = true
+  end
+
+  def formats
+    [:json]
+  end
+
+  def request
+    @request ||= ActionDispatch::Request.new({
+      'REQUEST_METHOD' => 'GET',
+      'REQUEST_URI' => 'http://test.host/foo'
+    })
+  end
+
+  def responder
+    Biceps::TestResponder
+  end
+end


### PR DESCRIPTION
Versioning routing is cool. But it's not enough !
So we've given a thought at model serializers versioning.

The idea is quite simple. For a model User :

```
class User < ActiveRecord::Base
end
```

You can add serializers, one per version. Serializers need a specific namespace : `Serializers::ModelName::Vx` where `ModelName` is your class's name, and `x` is the API version number.

So, for example, I could do :

```
class Serializers::Users::V1 < Biceps::Serializer
  def as_json(opts={})
    {:fullname => "#{parent.firstname} #{parent.lastname}"}
  end
end
```

With this, when someone requests your API at it's V1 to get a user, it will receive the following json :

```
{"fullname":"John Doe"}
```

For this to properly work, you need to include the biceps' responder into your application's responders. You can do it the following way :

```
class MyApp:Responder < ActionController::Responder
  include Biceps::ModelVersioning
end

class ApplicationController < ActionController::Base
  self.responder = MyApp::Responder
end
```

For now, we don't include automatically the responder anywhere.
But it might change someday so it gets easier to setup.
